### PR TITLE
feat: Artifacts Directory

### DIFF
--- a/bin/opup/src/stack/mod.rs
+++ b/bin/opup/src/stack/mod.rs
@@ -78,7 +78,7 @@ pub fn temp() -> Result<()> {
     // Setup
 
     tracing::info!(target: "opup", "Building devnet...");
-    std::fs::create_dir_all(devnet_dir)?;
+    stack.create_artifacts_dir()?;
     let curr_timestamp = clock::current_timestamp();
     let genesis_template = genesis::genesis_template(curr_timestamp);
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -89,6 +89,9 @@ pub struct Config {
     #[serde(skip)]
     pub profile: Profile,
 
+    /// The path to the op stack artifact directory. **(default: _default_ `.stack`)**
+    pub artifacts: PathBuf,
+
     /// The type of L1 Client to use. **(default: _default_ `L1Client::Geth`)**
     pub l1_client: L1Client,
     /// The type of L2 Client to use. **(default: _default_ `L2Client::Geth`)**
@@ -102,7 +105,7 @@ pub struct Config {
     /// Enable Sequencing. **(default: _default_ `false`)**
     pub enable_sequencing: bool,
     /// Enable Fault Proofs. **(default: _default_ `false`)**
-    pub enable_frault_proofs: bool,
+    pub enable_fault_proofs: bool,
 
     /// JWT secret that should be used for any rpc calls
     pub eth_rpc_jwt: Option<String>,
@@ -265,6 +268,14 @@ impl Config {
             __root: root::RootPath(root.into()),
             ..Config::default()
         }
+    }
+
+    /// Creates the artifacts directory if it doesn't exist.
+    pub fn create_artifacts_dir(&self) -> Result<()> {
+        if !self.artifacts.exists() {
+            std::fs::create_dir_all(&self.artifacts)?;
+        }
+        Ok(())
     }
 
     /// Returns the selected profile
@@ -430,12 +441,13 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             profile: Self::DEFAULT_PROFILE,
+            artifacts: PathBuf::from(Self::STACK_DIR_NAME),
             l1_client: L1Client::default(),
             l2_client: L2Client::default(),
             rollup_client: RollupClient::default(),
             challenger: ChallengerAgent::default(),
             enable_sequencing: false,
-            enable_frault_proofs: false,
+            enable_fault_proofs: false,
             eth_rpc_jwt: None,
             __root: RootPath::default(),
         }

--- a/crates/config/tests/config.rs
+++ b/crates/config/tests/config.rs
@@ -1,12 +1,38 @@
 use op_config::Config;
 use op_stack::{ChallengerAgent, L1Client, L2Client, RollupClient};
+use std::path::PathBuf;
 
 #[test]
 fn test_default_config() {
     let config = Config::default();
 
+    assert_eq!(config.artifacts, PathBuf::from(Config::STACK_DIR_NAME));
+
     assert_eq!(config.l1_client, L1Client::default());
     assert_eq!(config.l2_client, L2Client::default());
     assert_eq!(config.rollup_client, RollupClient::default());
     assert_eq!(config.challenger, ChallengerAgent::default());
+
+    assert_eq!(config.enable_sequencing, false);
+    assert_eq!(config.enable_fault_proofs, false);
+}
+
+#[test]
+fn test_create_artifacts_dir() {
+    // Create a temporary directory and set it as the current working directory.
+    // This directory will be deleted when the `tmpdir` variable goes out of scope.
+    let tmpdir = tempfile::tempdir().unwrap();
+    std::env::set_current_dir(&tmpdir).unwrap();
+
+    // Create a default configuration and create the artifact directory.
+    let config = Config::default();
+    config.create_artifacts_dir().unwrap();
+    assert!(config.artifacts.exists());
+    assert!(config.artifacts.is_dir());
+
+    // Drop the `tmpdir` variable, which deletes the temporary directory.
+    drop(tmpdir);
+
+    // The temporary directory should no longer exist.
+    assert!(!config.artifacts.exists());
 }


### PR DESCRIPTION
**Description**

Pulls the ".devnet" directory into the op stack config object as a new `artifacts` pathbuf.

The binary will still need to be updated to remove the current hardcoded path to the ".devnet" directory.
But before we can do this, the optimism monorepo cloning logic must be re-worked as a set of composable components.
