### PR TITLE
perf: download monorepo instead of cloning from git

### DIFF
--- a/crates/config/src/stack.rs
+++ b/crates/config/src/stack.rs
@@ -12,14 +12,13 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use tracing::trace;
 
-use op_primitives::{ChallengerAgent, L1Client, L2Client, RollupClient};
+use op_primitives::{ChallengerAgent, L1Client, L2Client, MonorepoConfig, RollupClient};
 
 use crate::providers::{
     error::ExtractConfigError, optional::OptionalStrictProfileProvider,
     rename::RenameProfileProvider, toml::TomlFileProvider, wraps::WrapProfileProvider,
 };
 use crate::root::RootPath;
-// use crate::stages::StageProvider;
 
 /// L1 node url.
 pub const L1_URL: &str = "http://localhost:8545";
@@ -92,6 +91,9 @@ pub struct Config<'a> {
 
     /// The path to the op stack artifact directory. **(default: _default_ `.stack`)**
     pub artifacts: PathBuf,
+
+    /// The Optimism Monorepo configuration options.
+    pub monorepo: MonorepoConfig,
 
     /// The type of L1 Client to use. **(default: _default_ `L1Client::Geth`)**
     pub l1_client: L1Client,
@@ -488,6 +490,7 @@ impl Default for Config<'_> {
             _phantom: PhantomData,
             profile: Self::DEFAULT_PROFILE,
             artifacts: PathBuf::from(Self::STACK_DIR_NAME),
+            monorepo: MonorepoConfig::default(),
             l1_client: L1Client::default(),
             l2_client: L2Client::default(),
             l1_client_url: Some(L1_URL.to_string()),

--- a/crates/primitives/src/monorepo.rs
+++ b/crates/primitives/src/monorepo.rs
@@ -43,6 +43,7 @@ impl Default for MonorepoConfig {
 
 /// The source from which to obtain the monorepo.
 #[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum MonorepoSource {
     /// Clone from git.
     Git,

--- a/crates/primitives/src/monorepo.rs
+++ b/crates/primitives/src/monorepo.rs
@@ -163,19 +163,10 @@ impl Monorepo {
         let archive_file_name = "optimism_monorepo.tar.gz";
 
         download_file(&self.pwd, &self.config.tarball_url, archive_file_name)?;
-        unzip_tarball(&self.pwd, archive_file_name)?; // This name is temporary as the archive file will be deleted
+        unzip_tarball(&self.pwd, archive_file_name)?;
         mv_dir(&self.pwd, "optimism-develop", &self.config.directory_name)?;
         std::fs::remove_file(archive_file_name)?;
         Ok(())
-    }
-}
-
-impl From<&Path> for Monorepo {
-    fn from(local: &Path) -> Self {
-        Self {
-            pwd: local.to_path_buf(),
-            config: MonorepoConfig::default(),
-        }
     }
 }
 

--- a/crates/primitives/src/monorepo.rs
+++ b/crates/primitives/src/monorepo.rs
@@ -136,7 +136,14 @@ impl Monorepo {
 
 impl Monorepo {
     /// Obtains the monorepo from the given source.
+    ///
+    /// If the monorepo already exists, this method will garacefully log a warning and return.
     pub fn obtain_from_source(&self) -> Result<()> {
+        if self.path().exists() {
+            tracing::warn!(target: "monorepo", "Monorepo already exists, skipping...");
+            return Ok(());
+        }
+
         match self.config.source {
             MonorepoSource::Git => self.git_clone(),
             MonorepoSource::Tarball => self.download(),

--- a/crates/stages/src/stages.rs
+++ b/crates/stages/src/stages.rs
@@ -100,7 +100,7 @@ impl Stages<'_> {
     pub async fn execute(&self) -> eyre::Result<()> {
         tracing::debug!(target: "stages", "executing stages");
 
-        let monorepo = Rc::new(Monorepo::new()?);
+        let monorepo = Rc::new(Monorepo::with_config(self.config.monorepo.clone())?);
 
         // todo: fix this to use the stack config once the artifacts directory is configurable in
         // docker containers.

--- a/crates/stages/src/stages/directories.rs
+++ b/crates/stages/src/stages/directories.rs
@@ -20,7 +20,8 @@ impl crate::Stage for Directories {
     fn execute(&self) -> Result<()> {
         tracing::info!(target: "stages", "Executing directories stage");
         self.artifacts.create()?;
-        self.monorepo.git_clone()
+
+        self.monorepo.obtain_from_source()
     }
 }
 


### PR DESCRIPTION
- closes #45 
- closes #56 

Improves the UX of using op-up by downloading a compressed archive instead of cloning the op monorepo.
The directory source is set to `MonorepoSource::Tarball` by default, but in the future this can be extended.

- Should we put this config option in the stack.toml?
- This PR adds the following dependencies: `curl`, `tar`. AFAIK they come preinstalled with all Unix systems though
- we could use the [curl](https://docs.rs/curl/latest/curl/) crate which embeds the `libcurl` bindings for us, I don't think that's necessary for now

I tested the download with this test:

```rust
mod tests {
    #[test]
    fn test_download_and_uncompress_tar() {
        let pwd = std::env::current_dir().unwrap();
        super::download_file(&pwd, super::OP_MONOREPO_TAR_URL, "optimism.tar.gz").unwrap();
        super::unzip_tarball(&pwd, "optimism.tar.gz").unwrap();
        super::mv_dir(&pwd, "optimism-develop", super::MONOREPO_DIR).unwrap();

        assert!(pwd.join(super::MONOREPO_DIR).exists());

        std::fs::remove_file(pwd.join("optimism.tar.gz")).unwrap();
        std::fs::remove_dir_all(pwd.join(super::MONOREPO_DIR)).unwrap();
    }
}

```

But it's a silly test to keep because it would download stuff on every test run – so I removed it from the pr.

