### PR TITLE
fix: rename cannon to fault proof prestate

### DIFF
--- a/crates/stages/src/stages.rs
+++ b/crates/stages/src/stages.rs
@@ -8,13 +8,13 @@ use op_primitives::{Artifacts, Monorepo};
 #[doc(hidden)]
 pub mod allocs;
 #[doc(hidden)]
-pub mod cannon;
-#[doc(hidden)]
 pub mod contracts;
 #[doc(hidden)]
 pub mod deploy_config;
 #[doc(hidden)]
 pub mod directories;
+#[doc(hidden)]
+pub mod prestate;
 
 #[doc(hidden)]
 pub mod l1_exec;
@@ -65,7 +65,7 @@ impl Stages<'_> {
                 Rc::clone(&artifacts),
                 Rc::clone(&monorepo),
             )),
-            Box::new(cannon::Prestate::new(Rc::clone(&monorepo))),
+            Box::new(prestate::Prestate::new(Rc::clone(&monorepo))),
             Box::new(allocs::Allocs::new(
                 Rc::clone(&artifacts),
                 Rc::clone(&monorepo),

--- a/crates/stages/src/stages/prestate.rs
+++ b/crates/stages/src/stages/prestate.rs
@@ -3,16 +3,16 @@ use op_primitives::Monorepo;
 use std::process::Command;
 use std::rc::Rc;
 
-/// Cannon Prestate Stage
+/// Fault proof Prestate Stage
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Prestate {
     monorepo: Rc<Monorepo>,
 }
 
 impl crate::Stage for Prestate {
-    /// Executes the cannon prestate stage.
+    /// Executes the fault proof prestate stage.
     fn execute(&self) -> Result<()> {
-        tracing::info!(target: "stages", "Executing cannon prestate stage");
+        tracing::info!(target: "stages", "Executing fault proof prestate stage");
 
         let monorepo = self.monorepo.path();
         let l2_genesis_file = self.monorepo.l2_genesis();
@@ -24,7 +24,7 @@ impl crate::Stage for Prestate {
 
         let op_program_bin = monorepo.join("op-program/bin");
         if std::fs::metadata(op_program_bin).is_ok() {
-            tracing::info!(target: "stages", "cannon prestate already generated");
+            tracing::info!(target: "stages", "Fault proof prestate already generated");
             return Ok(());
         }
 
@@ -35,7 +35,7 @@ impl crate::Stage for Prestate {
 
         if !make.status.success() {
             eyre::bail!(
-                "failed to generate cannon prestate: {}",
+                "failed to generate fault proof prestate: {}",
                 String::from_utf8_lossy(&make.stderr)
             );
         }


### PR DESCRIPTION
- closes #44 