### PR TITLE
feat(bin): Force Overwrite CLI Flag

### DIFF
--- a/bin/opup/src/up.rs
+++ b/bin/opup/src/up.rs
@@ -52,7 +52,9 @@ impl UpCommand {
 
             if self.devnet {
                 tracing::info!(target: "cli", "Building default devnet stack");
-                Stages::from(Config::default()).execute().await
+                Stages::from(Config::default().force_overwrites(self.force))
+                    .execute()
+                    .await
             } else {
                 // Get the directory of the config file if it exists.
                 let config_dir = self.config.as_ref().and_then(|p| p.parent());
@@ -60,7 +62,7 @@ impl UpCommand {
 
                 // Build a config from the parsed config directory.
                 tracing::info!(target: "cli", "Loading op-stack config from {:?}", config_dir);
-                let stack = Config::load_with_root(config_dir);
+                let stack = Config::load_with_root(config_dir).force_overwrites(self.force);
 
                 tracing::info!(target: "cli", "Stack: {:#?}", stack);
 

--- a/bin/opup/src/up.rs
+++ b/bin/opup/src/up.rs
@@ -28,7 +28,11 @@ pub struct UpCommand {
 impl UpCommand {
     /// Create a new Up CLI Subcommand.
     pub fn new(config: Option<PathBuf>, devnet: bool) -> Self {
-        Self { config, devnet }
+        Self {
+            config,
+            devnet,
+            force: false,
+        }
     }
 
     /// Run the Up CLI Subcommand.

--- a/bin/opup/src/up.rs
+++ b/bin/opup/src/up.rs
@@ -16,6 +16,13 @@ pub struct UpCommand {
     /// Whether to build a hard-coded default devnet stack, ignoring the config file.
     #[arg(long, short)]
     pub devnet: bool,
+
+    /// Force enables op-up to enter overwrite mode.
+    ///
+    /// It enables overwriting of persistant artifacts from previous runs,
+    /// for example, git repository clones.
+    #[arg(long, short)]
+    pub force: bool,
 }
 
 impl UpCommand {
@@ -34,6 +41,10 @@ impl UpCommand {
             let docker = Docker::connect_with_local_defaults()?;
             let version = docker.version().await?;
             tracing::info!(target: "cli", "docker version: {:?}", version);
+
+            // todo get the force arg and pass it into the stages pipeline
+            // should the stack config be transformed to include this and
+            // other flags?
 
             if self.devnet {
                 tracing::info!(target: "cli", "Building default devnet stack");

--- a/crates/config/src/stack.rs
+++ b/crates/config/src/stack.rs
@@ -342,6 +342,12 @@ impl Config<'_> {
         dirs_next::home_dir().map(|p| p.join(Config::STACK_DIR_NAME))
     }
 
+    /// Force monorepo artifact overwrites.
+    pub fn force_overwrites(mut self, force: bool) -> Self {
+        self.monorepo.force = force;
+        self
+    }
+
     /// Sets the l1 client to use via a cli prompt.
     pub fn set_l1_client(&mut self) -> Result<()> {
         make_selection!(

--- a/crates/primitives/src/monorepo.rs
+++ b/crates/primitives/src/monorepo.rs
@@ -27,6 +27,8 @@ pub struct MonorepoConfig {
     pub git_url: String,
     /// The URL from which to download the Optimism Monorepo tarball.
     pub tarball_url: String,
+    /// Optionally force overwriting local monorepo artifacts.
+    pub force: bool,
 }
 
 impl Default for MonorepoConfig {
@@ -37,6 +39,7 @@ impl Default for MonorepoConfig {
             git_url: "git@github.com:ethereum-optimism/optimism.git".to_string(),
             tarball_url: "https://github.com/ethereum-optimism/optimism/archive/develop.tar.gz"
                 .to_string(),
+            force: false,
         }
     }
 }
@@ -140,7 +143,7 @@ impl Monorepo {
     ///
     /// If the monorepo already exists, this method will garacefully log a warning and return.
     pub fn obtain_from_source(&self) -> Result<()> {
-        if self.path().exists() {
+        if self.path().exists() && !self.config.force {
             tracing::warn!(target: "monorepo", "Monorepo already exists, skipping...");
             return Ok(());
         }


### PR DESCRIPTION
**Description**

Adds a `--force` cli flag that allows for monorepo artifacts to be overridden. Currently the propagation of the `force` option down through the stack config uses an internal builder pattern in an ugly fashion. This should be fixed as well as hoisting the `force` flag and potentially renaming it.