### PR TITLE
feat: first docker container running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,9 +1666,11 @@ version = "0.1.0"
 dependencies = [
  "bollard",
  "eyre",
+ "flate2",
  "futures-util",
  "pretty_assertions",
  "serde",
+ "tar",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2753,6 +2767,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "temp_testdir"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,6 +3482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,6 +1548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +1747,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "eyre",
+ "maplit",
  "op-composer",
  "op-config",
  "op-contracts",

--- a/bin/opup/src/deps.rs
+++ b/bin/opup/src/deps.rs
@@ -82,9 +82,10 @@ impl DependencyManager {
             return Ok(());
         }
         let version = semver::Version::parse("0.8.17")?;
-        tracing::info!("Installing Solidity version {:?}", version);
+        tracing::info!("Installing Solidity version {}", version);
         let _ = svm_lib::install(&version).await?;
-        tracing::info!("Solidity version {:?} installed", version);
+        svm_lib::use_version(&version)?;
+        tracing::info!("Solidity version {} installed", version);
         Ok(())
     }
 

--- a/bin/opup/src/up.rs
+++ b/bin/opup/src/up.rs
@@ -59,7 +59,7 @@ impl UpCommand {
     }
 
     /// Entrypoint
-    #[instrument(name = "up", target = "run")]
+    #[instrument(name = "up", target = "run", skip(self))]
     pub fn run(&self) -> Result<()> {
         crate::runner::run_until_ctrl_c(async { self.execute().await })
     }

--- a/crates/composer/Cargo.toml
+++ b/crates/composer/Cargo.toml
@@ -18,6 +18,8 @@ serde.workspace = true
 tokio = { version = "1.11.0", features = ["full"] }
 futures-util = "0.3.28"
 bollard = "0.15.0"
+flate2 = "1.0.28"
+tar = "0.4.40"
 
 [dev-dependencies]
 tracing-subscriber.workspace = true

--- a/crates/composer/src/lib.rs
+++ b/crates/composer/src/lib.rs
@@ -95,7 +95,7 @@ impl Composer {
 
         tracing::debug!(target: "composer", "Created docker image: {:?}", res);
 
-        match res.get(0) {
+        match res.first() {
             Some(info) => match info.id.as_ref() {
                 Some(id) => Ok(id.clone()),
                 None => bail!("No image ID found in response"),
@@ -124,8 +124,9 @@ impl Composer {
                 .build_image(build_options, None, Some(files.into()));
 
         while let Some(build_info) = image_build_stream.next().await {
-            println!("Response: {:?}", build_info);
-            tracing::debug!(target: "composer", "Build info: {:?}", build_info);
+            let res = build_info?;
+            println!("Response: {:?}", res);
+            tracing::debug!(target: "composer", "Build info: {:?}", res);
         }
 
         Ok(())

--- a/crates/composer/src/lib.rs
+++ b/crates/composer/src/lib.rs
@@ -16,6 +16,7 @@ use bollard::{
         StartContainerOptions, StopContainerOptions,
     },
     exec::{CreateExecOptions, StartExecResults},
+    image::BuildImageOptions,
     service::{ContainerCreateResponse, ContainerSummary},
     Docker,
 };
@@ -25,6 +26,9 @@ use serde::Serialize;
 
 pub use bollard::image::CreateImageOptions;
 pub use bollard::service::ContainerConfig;
+
+/// Utilities for Docker operations
+mod utils;
 
 /// The Composer is responsible for managing the OP-UP docker containers.
 #[derive(Debug)]
@@ -98,11 +102,42 @@ impl Composer {
         }
     }
 
+    /// Build a Docker image from a build context tarball.
+    ///
+    /// The compressed tarball can be generated with the
+    /// [`dockerfile_build_context!`] macro.
+    pub async fn build_image(
+        &self,
+        name: &str,
+        dockerfile: &str,
+        build_context_files: Vec<(&str, &[u8])>,
+    ) -> Result<()> {
+        let build_options = BuildImageOptions {
+            t: name,
+            dockerfile: "Dockerfile",
+            pull: true,
+            ..Default::default()
+        };
+
+        let files = utils::create_dockerfile_build_context(dockerfile, build_context_files)?;
+        let mut image_build_stream =
+            self.daemon
+                .build_image(build_options, None, Some(files.into()));
+
+        while let Some(build_info) = image_build_stream.next().await {
+            println!("Response: {:?}", build_info);
+            tracing::debug!(target: "composer", "Build info: {:?}", build_info);
+        }
+
+        Ok(())
+    }
+
     /// Create a Docker container for the specified OP Stack component
     pub async fn create_container(
         &self,
         name: &str,
         mut config: ContainerConfig,
+        overwrite: bool,
     ) -> Result<ContainerCreateResponse> {
         let create_options = CreateContainerOptions {
             name,
@@ -115,24 +150,38 @@ impl Composer {
             "op-up".to_string(),
         );
 
-        // Check if a container already exists with the specified name.
-        // If so, return the existing container ID instead
+        // Check if a container already exists with the specified name. If it does:
+        // - If overwrite is true, remove the existing container and create a new one.
+        // - If overwrite is false, return the existing container ID.
         let containers = self.list_containers(None).await?;
         if let Some(container) = containers.iter().find(|container| {
             container
                 .names
                 .as_ref()
-                .map(|names| names.iter().any(|n| n == name))
+                .map(|names| {
+                    names
+                        .iter()
+                        .any(|n| n == name || n == &format!("/{}", name))
+                })
                 .unwrap_or(false)
         }) {
             tracing::debug!(target: "composer", "Container {} already exists", name);
-            return Ok(ContainerCreateResponse {
-                id: container
-                    .id
-                    .clone()
-                    .ok_or_else(|| eyre::eyre!("No container ID found"))?,
-                warnings: vec![],
-            });
+            let id = container
+                .id
+                .clone()
+                .ok_or_else(|| eyre::eyre!("No container ID found"))?;
+
+            if overwrite {
+                self.daemon
+                    .remove_container(&id, None::<RemoveContainerOptions>)
+                    .await?;
+                tracing::debug!(target: "composer", "Removed existing docker container {}", name);
+            } else {
+                return Ok(ContainerCreateResponse {
+                    id,
+                    warnings: vec![],
+                });
+            }
         }
 
         let res = self

--- a/crates/composer/src/lib.rs
+++ b/crates/composer/src/lib.rs
@@ -126,7 +126,6 @@ impl Composer {
 
         while let Some(build_info) = image_build_stream.next().await {
             let res = build_info?;
-            println!("Response: {:?}", res);
             tracing::debug!(target: "composer", "Build info: {:?}", res);
         }
 

--- a/crates/composer/src/lib.rs
+++ b/crates/composer/src/lib.rs
@@ -17,7 +17,7 @@ use bollard::{
     },
     exec::{CreateExecOptions, StartExecResults},
     image::BuildImageOptions,
-    service::{ContainerCreateResponse, ContainerSummary},
+    service::{ContainerCreateResponse, ContainerSummary, Volume},
     Docker,
 };
 use eyre::{bail, Result};
@@ -27,6 +27,7 @@ use serde::Serialize;
 pub use bollard::container::Config;
 pub use bollard::image::CreateImageOptions;
 pub use bollard::service::HostConfig;
+pub use bollard::volume::CreateVolumeOptions;
 pub use utils::bind_host_port;
 
 /// Utilities for Docker operations
@@ -130,6 +131,14 @@ impl Composer {
         }
 
         Ok(())
+    }
+
+    /// Creates a Docker volume with the specified options.
+    pub async fn create_volume<T>(&self, config: CreateVolumeOptions<T>) -> Result<Volume>
+    where
+        T: Into<String> + Serialize + Eq + std::hash::Hash,
+    {
+        self.daemon.create_volume(config).await.map_err(Into::into)
     }
 
     /// Create a Docker container for the specified OP Stack component

--- a/crates/composer/src/utils.rs
+++ b/crates/composer/src/utils.rs
@@ -1,0 +1,36 @@
+use std::io::Write;
+
+use eyre::Result;
+use flate2::{write::GzEncoder, Compression};
+
+/// Given a dockerfile string and any number of files as `(filename, file contents)`,
+/// create a tarball and gzip the tarball. Returns the compressed output bytes.
+pub(crate) fn create_dockerfile_build_context(
+    dockerfile: &str,
+    files: Vec<(&str, &[u8])>,
+) -> Result<Vec<u8>> {
+    // First create a Dockerfile tarball
+    let mut header = tar::Header::new_gnu();
+    header.set_path("Dockerfile")?;
+    header.set_size(dockerfile.len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    let mut tar = tar::Builder::new(Vec::new());
+    tar.append(&header, dockerfile.as_bytes())?;
+
+    // Then append any additional files
+    for (filename, contents) in files {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(filename)?;
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        tar.append(&header, contents)?;
+    }
+
+    // Finally, gzip the tarball
+    let uncompressed = tar.into_inner()?;
+    let mut c = GzEncoder::new(Vec::new(), Compression::default());
+    c.write_all(&uncompressed)?;
+    c.finish().map_err(Into::into)
+}

--- a/crates/composer/tests/basic.rs
+++ b/crates/composer/tests/basic.rs
@@ -32,7 +32,7 @@ pub async fn test_basic_docker_composer() -> eyre::Result<()> {
         };
 
         let container = composer
-            .create_container("test_basic_docker_composer", container_config)
+            .create_container("test_basic_docker_composer", container_config, false)
             .await?;
 
         // 3. Start running container

--- a/crates/composer/tests/basic.rs
+++ b/crates/composer/tests/basic.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use bollard::{image::CreateImageOptions, service::ContainerConfig};
-use op_composer::Composer;
+use bollard::image::CreateImageOptions;
+use op_composer::{Composer, Config};
 
 /// This is a basic test of the Composer functionality to create and start a Docker container, run a simple
 /// command in the container, and then stop and remove it. If the Docker daemon is not running, this test
@@ -22,7 +22,7 @@ pub async fn test_basic_docker_composer() -> eyre::Result<()> {
         composer.create_image(image_config).await?;
 
         // 2. Create the container with the new image
-        let container_config = ContainerConfig {
+        let container_config = Config {
             exposed_ports: Some(HashMap::<_, _>::from_iter([(
                 "7777".to_string(),
                 HashMap::new(),

--- a/crates/composer/tests/basic.rs
+++ b/crates/composer/tests/basic.rs
@@ -34,10 +34,6 @@ pub async fn test_basic_docker_composer() -> eyre::Result<()> {
         let container = composer
             .create_container("test_basic_docker_composer", container_config)
             .await?;
-        println!("Created container: {:?}", container);
-
-        let all_containers = composer.list_containers(None).await?;
-        assert_eq!(all_containers.len(), 1);
 
         // 3. Start running container
         composer.start_container(&container.id).await?;

--- a/crates/primitives/src/components/challenger.rs
+++ b/crates/primitives/src/components/challenger.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 
 /// Challenger Agent Implementations
-#[derive(Default, Clone, PartialEq, EnumVariantsStrings, Deserialize, Serialize, EnumIter)]
+#[derive(
+    Default, Copy, Clone, PartialEq, EnumVariantsStrings, Deserialize, Serialize, EnumIter,
+)]
 #[serde(rename_all = "kebab-case")]
 #[enum_variants_strings_transform(transform = "kebab_case")]
 pub enum ChallengerAgent {

--- a/crates/primitives/src/components/layer_one.rs
+++ b/crates/primitives/src/components/layer_one.rs
@@ -7,7 +7,9 @@ use strum::EnumIter;
 /// L1 Client
 ///
 /// The OP Stack L1 client is an L1 execution client.
-#[derive(Default, Clone, PartialEq, EnumVariantsStrings, Deserialize, Serialize, EnumIter)]
+#[derive(
+    Default, Copy, Clone, PartialEq, EnumVariantsStrings, Deserialize, Serialize, EnumIter,
+)]
 #[serde(rename_all = "kebab-case")]
 #[enum_variants_strings_transform(transform = "kebab_case")]
 pub enum L1Client {

--- a/crates/primitives/src/components/layer_two.rs
+++ b/crates/primitives/src/components/layer_two.rs
@@ -9,7 +9,9 @@ use strum::EnumIter;
 /// The OP Stack L2 client is a minimally modified version of the L1 client
 /// that supports deposit transactions as well as a few other small OP-specific
 /// changes.
-#[derive(Default, Clone, PartialEq, EnumVariantsStrings, Deserialize, Serialize, EnumIter)]
+#[derive(
+    Default, Copy, Clone, PartialEq, EnumVariantsStrings, Deserialize, Serialize, EnumIter,
+)]
 #[serde(rename_all = "kebab-case")]
 #[enum_variants_strings_transform(transform = "kebab_case")]
 pub enum L2Client {

--- a/crates/primitives/src/components/rollup.rs
+++ b/crates/primitives/src/components/rollup.rs
@@ -8,7 +8,9 @@ use strum::EnumIter;
 ///
 /// The OP Stack rollup client performs the derivation of the rollup state
 /// from the L1 and L2 clients.
-#[derive(Default, Clone, PartialEq, EnumVariantsStrings, Deserialize, Serialize, EnumIter)]
+#[derive(
+    Default, Copy, Clone, PartialEq, EnumVariantsStrings, Deserialize, Serialize, EnumIter,
+)]
 #[serde(rename_all = "kebab-case")]
 #[enum_variants_strings_transform(transform = "kebab_case")]
 pub enum RollupClient {

--- a/crates/stages/Cargo.toml
+++ b/crates/stages/Cargo.toml
@@ -23,3 +23,4 @@ serde_json.workspace = true
 
 async-trait = "0.1.73"
 project-root = "0.2.2"
+maplit = "1.0.2"

--- a/crates/stages/src/stages.rs
+++ b/crates/stages/src/stages.rs
@@ -59,10 +59,7 @@ impl Stages<'_> {
         composer: Arc<op_composer::Composer>,
     ) -> Vec<Box<dyn crate::Stage>> {
         let genesis_timestamp = genesis::current_timestamp();
-        let l1_client = self.config.l1_client.to_string();
-        let l2_client = self.config.l2_client.to_string();
-        let rollup_client = self.config.rollup_client.to_string();
-        let challenge_agent = self.config.challenger.to_string();
+
         vec![
             Box::new(directories::Directories::new(
                 Arc::clone(&artifacts),
@@ -83,7 +80,7 @@ impl Stages<'_> {
             )),
             Box::new(l1_exec::Executor::new(
                 self.config.l1_client_port,
-                l1_client,
+                self.config.l1_client,
                 composer,
                 Arc::clone(&artifacts),
             )),
@@ -94,11 +91,11 @@ impl Stages<'_> {
             Box::new(contracts::Contracts::new()),
             Box::new(l2_exec::Executor::new(
                 self.config.l2_client_port,
-                l2_client,
+                self.config.l2_client.to_string(),
             )),
             Box::new(rollup::Rollup::new(
                 self.config.rollup_client_port,
-                rollup_client,
+                self.config.rollup_client.to_string(),
             )),
             Box::new(proposer::Proposer::new(Arc::clone(&artifacts))),
             Box::new(batcher::Batcher::new(
@@ -107,7 +104,7 @@ impl Stages<'_> {
             )),
             Box::new(challenger::Challenger::new(
                 Arc::clone(&artifacts),
-                challenge_agent,
+                self.config.challenger.to_string(),
             )),
             Box::new(stateviz::Stateviz::new(Arc::clone(&artifacts))),
         ]

--- a/crates/stages/src/stages.rs
+++ b/crates/stages/src/stages.rs
@@ -91,11 +91,11 @@ impl Stages<'_> {
             Box::new(contracts::Contracts::new()),
             Box::new(l2_exec::Executor::new(
                 self.config.l2_client_port,
-                self.config.l2_client.to_string(),
+                self.config.l2_client,
             )),
             Box::new(rollup::Rollup::new(
                 self.config.rollup_client_port,
-                self.config.rollup_client.to_string(),
+                self.config.rollup_client,
             )),
             Box::new(proposer::Proposer::new(Arc::clone(&artifacts))),
             Box::new(batcher::Batcher::new(
@@ -104,7 +104,7 @@ impl Stages<'_> {
             )),
             Box::new(challenger::Challenger::new(
                 Arc::clone(&artifacts),
-                self.config.challenger.to_string(),
+                self.config.challenger,
             )),
             Box::new(stateviz::Stateviz::new(Arc::clone(&artifacts))),
         ]

--- a/crates/stages/src/stages.rs
+++ b/crates/stages/src/stages.rs
@@ -76,6 +76,7 @@ impl Stages<'_> {
             )),
             Box::new(l1_genesis::L1Genesis::new(
                 Arc::clone(&monorepo),
+                Arc::clone(&artifacts),
                 genesis_timestamp,
             )),
             Box::new(l1_exec::Executor::new(

--- a/crates/stages/src/stages/challenger.rs
+++ b/crates/stages/src/stages/challenger.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use eyre::Result;
-use op_primitives::Artifacts;
+use op_primitives::{Artifacts, ChallengerAgent};
 use std::process::Command;
 use std::sync::Arc;
 
@@ -8,7 +8,7 @@ use std::sync::Arc;
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Challenger {
     artifacts: Arc<Artifacts>,
-    challenger: String,
+    challenger: ChallengerAgent,
 }
 
 #[async_trait]
@@ -30,7 +30,7 @@ impl crate::Stage for Challenger {
             .env("PWD", &docker_dir)
             .env("L2OO_ADDRESS", addresses["L2OutputOracleProxy"].to_string())
             .env("DGF_ADDRESS", addresses["DisputeGameFactory"].to_string())
-            .env("CHALLENGER_AGENT_CHOICE", &self.challenger)
+            .env("CHALLENGER_AGENT_CHOICE", &self.challenger.to_string())
             .current_dir(docker_dir)
             .output()?;
 
@@ -48,7 +48,7 @@ impl crate::Stage for Challenger {
 
 impl Challenger {
     /// Creates a new challenger stage.
-    pub fn new(artifacts: Arc<Artifacts>, challenger: String) -> Self {
+    pub fn new(artifacts: Arc<Artifacts>, challenger: ChallengerAgent) -> Self {
         Self {
             artifacts,
             challenger,

--- a/crates/stages/src/stages/l1_exec.rs
+++ b/crates/stages/src/stages/l1_exec.rs
@@ -1,4 +1,5 @@
 use eyre::Result;
+use op_composer::CreateImageOptions;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -23,15 +24,23 @@ impl crate::Stage for Executor {
     async fn execute(&self) -> Result<()> {
         tracing::info!(target: "stages", "Executing l1 execution client stage");
 
+        let image_name = "ethereum/client-go:v1.12.2".to_string();
         let working_dir = project_root::get_project_root()?.join("docker");
         let l1_genesis = self.artifacts.l1_genesis();
         let jwt_secret = self.artifacts.jwt_secret();
+
+        let image_config = CreateImageOptions {
+            from_image: image_name.as_str(),
+            ..Default::default()
+        };
+        self.l1_exec.create_image(image_config).await?;
+
         let config = ContainerConfig {
             cmd: Some(vec![
-                "/bin/sh".to_string(),
+                "/bin/sh".to_string(), // TODO: fix this: we need to place here the actual geth start command
                 "geth-entrypoint.sh".to_string(),
             ]),
-            image: Some("ethereum/client-go:v1.12.2".to_string()),
+            image: Some(image_name),
             working_dir: Some(working_dir.to_string_lossy().to_string()),
             volumes: Some(HashMap::from([
                 ("l1_data:/db".to_string(), HashMap::new()),
@@ -55,14 +64,22 @@ impl crate::Stage for Executor {
             ..Default::default()
         };
 
-        let response = self
+        let container_id = self
             .l1_exec
             .create_container(&self.l1_client, config)
-            .await?;
-        tracing::info!(target: "stages", "l1 container created: {:?}", response);
+            .await?
+            .id;
+
+        let all_containers = self.l1_exec.list_containers(None).await?;
+        tracing::info!(target: "stages", "all containers: {:?}", all_containers);
+
+        tracing::info!(target: "stages", "l1 container created: {}", container_id);
+
+        self.l1_exec.start_container(&container_id).await?;
 
         let l1_port = self.l1_port.unwrap_or(op_config::L1_PORT);
-        crate::net::wait_up(l1_port, 10, 1)?;
+        crate::net::wait_up(l1_port, 10, 3)?;
+        tracing::info!(target: "stages", "l1 container started on port: {}", l1_port);
 
         // todo: do we need to do block here
         // can we wait for the l1 client to be ready by polling?
@@ -88,3 +105,39 @@ impl Executor {
         }
     }
 }
+
+// For reference, here is the geth startup command in geth-entrypoint.sh:
+//
+// exec geth \
+// 	--datadir="$GETH_DATA_DIR" \
+// 	--verbosity="$VERBOSITY" \
+// 	--http \
+// 	--http.corsdomain="*" \
+// 	--http.vhosts="*" \
+// 	--http.addr=0.0.0.0 \
+// 	--http.port="$RPC_PORT" \
+// 	--http.api=web3,debug,eth,txpool,net,engine \
+// 	--ws \
+// 	--ws.addr=0.0.0.0 \
+// 	--ws.port="$WS_PORT" \
+// 	--ws.origins="*" \
+// 	--ws.api=debug,eth,txpool,net,engine \
+// 	--syncmode=full \
+// 	--nodiscover \
+// 	--maxpeers=1 \
+// 	--networkid=$CHAIN_ID \
+// 	--unlock=$BLOCK_SIGNER_ADDRESS \
+// 	--mine \
+// 	--miner.etherbase=$BLOCK_SIGNER_ADDRESS \
+// 	--password="$GETH_DATA_DIR"/password \
+// 	--allow-insecure-unlock \
+// 	--rpc.allow-unprotected-txs \
+// 	--authrpc.addr="0.0.0.0" \
+// 	--authrpc.port="8551" \
+// 	--authrpc.vhosts="*" \
+// 	--authrpc.jwtsecret=/config/test-jwt-secret.txt \
+// 	--gcmode=archive \
+// 	--metrics \
+// 	--metrics.addr=0.0.0.0 \
+// 	--metrics.port=6060 \
+// 	"$@"

--- a/crates/stages/src/stages/l1_exec.rs
+++ b/crates/stages/src/stages/l1_exec.rs
@@ -1,6 +1,6 @@
 use eyre::Result;
+use maplit::hashmap;
 use op_primitives::L1Client;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -73,26 +73,16 @@ impl Executor {
         let config = ContainerConfig {
             image: Some(image_name),
             working_dir: Some(working_dir.to_string_lossy().to_string()),
-            volumes: Some(HashMap::from([
-                // TODO: double check source/destination of volumes
-                ("l1_data:/db".to_string(), HashMap::new()),
-                (
-                    format!("{}:/genesis.json", l1_genesis.to_string_lossy()),
-                    HashMap::new(),
-                ),
-                (
-                    format!(
-                        "{}:/config/test-jwt-secret.txt",
-                        jwt_secret.to_string_lossy()
-                    ),
-                    HashMap::new(),
-                ),
-            ])),
-            exposed_ports: Some(HashMap::from([
-                ("8545:8545".to_string(), HashMap::new()),
-                ("8546:8546".to_string(), HashMap::new()),
-                ("7060:6060".to_string(), HashMap::new()),
-            ])),
+            volumes: Some(hashmap! {
+                "l1_data:/db".to_string() => hashmap! {},
+                format!("{}:/genesis.json", l1_genesis.to_string_lossy()) => hashmap! {},
+                format!("{}:/config/test-jwt-secret.txt", jwt_secret.to_string_lossy()) => hashmap! {}
+            }),
+            exposed_ports: Some(hashmap! {
+                "8545:8545".to_string() => hashmap! {},
+                "8546:8546".to_string() => hashmap! {},
+                "7060:6060".to_string() => hashmap! {},
+            }),
             ..Default::default()
         };
 

--- a/crates/stages/src/stages/l1_genesis.rs
+++ b/crates/stages/src/stages/l1_genesis.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use eyre::Result;
-use op_primitives::{path_to_str, Monorepo};
+use op_primitives::{path_to_str, Artifacts, Monorepo};
 use std::process::Command;
 use std::sync::Arc;
 
@@ -8,6 +8,7 @@ use std::sync::Arc;
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct L1Genesis {
     monorepo: Arc<Monorepo>,
+    artifacts: Arc<Artifacts>,
     genesis_timestamp: u64,
 }
 
@@ -17,16 +18,27 @@ impl crate::Stage for L1Genesis {
     async fn execute(&self) -> Result<()> {
         tracing::info!(target: "stages", "Executing l1 genesis stage");
 
+        // Artifacts paths
+        let l1_genesis_artifact = self.artifacts.l1_genesis();
+        let addresses_json_artifact = self.artifacts.l1_deployments();
+        let addresses_json_artifact = path_to_str!(addresses_json_artifact)?;
+        let jwt_secret_artifact = self.artifacts.jwt_secret();
+
+        // Monorepo paths
         let deploy_config = self.monorepo.deploy_config();
         let deploy_config = path_to_str!(deploy_config)?;
         let allocs = self.monorepo.allocs();
         let allocs = path_to_str!(allocs)?;
-        let l1_genesis = self.monorepo.l1_genesis();
-        let addresses_json = self.monorepo.addresses_json();
-        let addresses_json = path_to_str!(addresses_json)?;
         let op_node_dir = self.monorepo.op_node_dir();
 
-        if l1_genesis.exists() {
+        if !jwt_secret_artifact.exists() {
+            tracing::info!(target: "stages", "Creating jwt secret...");
+            // TODO: take this from the TOML stack config
+            let jwt_secret = "688f5d737bad920bdfb2fc2f488d6b6209eebda1dae949a8de91398d932c517a";
+            std::fs::write(&jwt_secret_artifact, jwt_secret)?;
+        }
+
+        if l1_genesis_artifact.exists() {
             tracing::info!(target: "stages", "L1 genesis already found.");
             return Ok(());
         }
@@ -35,14 +47,14 @@ impl crate::Stage for L1Genesis {
         let genesis_template =
             op_primitives::genesis::genesis_template_string(self.genesis_timestamp)
                 .ok_or_else(|| eyre::eyre!("Could not create genesis template"))?;
-        std::fs::write(&l1_genesis, genesis_template)?;
-        let l1_genesis_str = path_to_str!(l1_genesis)?;
+        std::fs::write(&l1_genesis_artifact, genesis_template)?;
+        let l1_genesis_artifact = path_to_str!(l1_genesis_artifact)?;
         let l1_genesis = Command::new("go")
             .args(["run", "cmd/main.go", "genesis", "l1"])
             .args(["--deploy-config", deploy_config])
             .args(["--l1-allocs", allocs])
-            .args(["--l1-deployments", addresses_json])
-            .args(["--outfile.l1", l1_genesis_str])
+            .args(["--l1-deployments", addresses_json_artifact])
+            .args(["--outfile.l1", l1_genesis_artifact])
             .current_dir(op_node_dir)
             .output()?;
 
@@ -59,9 +71,10 @@ impl crate::Stage for L1Genesis {
 
 impl L1Genesis {
     /// Creates a new stage.
-    pub fn new(monorepo: Arc<Monorepo>, genesis_timestamp: u64) -> Self {
+    pub fn new(monorepo: Arc<Monorepo>, artifacts: Arc<Artifacts>, genesis_timestamp: u64) -> Self {
         Self {
             monorepo,
+            artifacts,
             genesis_timestamp,
         }
     }

--- a/crates/stages/src/stages/l2_exec.rs
+++ b/crates/stages/src/stages/l2_exec.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
 use eyre::Result;
+use op_primitives::L2Client;
 use std::process::Command;
 
 /// Layer 2 Execution Client Stage
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Executor {
     l2_port: Option<u16>,
-    l2_client: String,
+    l2_client: L2Client,
 }
 
 #[async_trait]
@@ -23,7 +24,7 @@ impl crate::Stage for Executor {
         let start_l2 = Command::new("docker-compose")
             .args(["up", "-d", "--no-deps", "--build", "l2"])
             .env("PWD", &docker_dir)
-            .env("L2_CLIENT_CHOICE", &self.l2_client)
+            .env("L2_CLIENT_CHOICE", &self.l2_client.to_string())
             .current_dir(docker_dir)
             .output()?;
 
@@ -41,7 +42,7 @@ impl crate::Stage for Executor {
 
 impl Executor {
     /// Creates a new stage.
-    pub fn new(l2_port: Option<u16>, l2_client: String) -> Self {
+    pub fn new(l2_port: Option<u16>, l2_client: L2Client) -> Self {
         Self { l2_port, l2_client }
     }
 }

--- a/crates/stages/src/stages/rollup.rs
+++ b/crates/stages/src/stages/rollup.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
 use eyre::Result;
+use op_primitives::RollupClient;
 use std::process::Command;
 
 /// Rollup Stage
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Rollup {
     rollup_port: Option<u16>,
-    rollup_client: String,
+    rollup_client: RollupClient,
 }
 
 #[async_trait]
@@ -24,7 +25,7 @@ impl crate::Stage for Rollup {
         let start_rollup = Command::new("docker-compose")
             .args(["up", "-d", "--no-deps", "--build", "rollup-client"])
             .env("PWD", &docker_dir)
-            .env("ROLLUP_CLIENT_CHOICE", &self.rollup_client)
+            .env("ROLLUP_CLIENT_CHOICE", &self.rollup_client.to_string())
             .current_dir(docker_dir)
             .output()?;
 
@@ -42,7 +43,7 @@ impl crate::Stage for Rollup {
 
 impl Rollup {
     /// Creates a new stage.
-    pub fn new(rollup_port: Option<u16>, rollup_client: String) -> Self {
+    pub fn new(rollup_port: Option<u16>, rollup_client: RollupClient) -> Self {
         Self {
             rollup_port,
             rollup_client,


### PR DESCRIPTION
We can now boot _Geth_ from inside Docker by running the opup command. 
"It works on my machine" (but I can't make any reliability remarks yet)

## Changes

The main addition is the `create_dockerfile_build_context()` function in the composer crate. It allows us to generate a "build context" for any image we might want to build _from scratch_. You just need to supply a Dockerfile and any necessary files that are referenced inside it. They are then added to a tarball archive and gzipped, and fed to the native `build_image` Docker API.

Also now we can pattern match on client enum variants to have separate functions for each of them:

```rust
match self.l1_client {
    L1Client::Geth => self.start_geth().await?,
    _ => unimplemented!("l1 client not implemented: {}", self.l1_client),
}
```

I realize this is bad for client generalization (aka: bring your own client by just touching a TOML) but we're not there yet!