### PR TITLE
chore(git): HTTPS Clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,14 +3290,15 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/primitives/src/monorepo.rs
+++ b/crates/primitives/src/monorepo.rs
@@ -36,7 +36,7 @@ impl Default for MonorepoConfig {
         Self {
             source: MonorepoSource::Git,
             directory_name: "optimism".to_string(),
-            git_url: "git@github.com:ethereum-optimism/optimism.git".to_string(),
+            git_url: "https://github.com/ethereum-optimism/optimism".to_string(),
             tarball_url: "https://github.com/ethereum-optimism/optimism/archive/develop.tar.gz"
                 .to_string(),
             force: false,


### PR DESCRIPTION
**Description**

Clone with https. Ssh is fickle when privileged git users are missing ssh keys for authentication with github. Instead, we can just use https to provide a secure, less fallible clone.
