### PR TITLE
feat: watch command

### DIFF
--- a/bin/opup/src/cli.rs
+++ b/bin/opup/src/cli.rs
@@ -29,6 +29,10 @@ pub enum Command {
     Clean,
     /// List op-up docker containers
     List,
+    /// Watch the devnet stack components.
+    /// This will output a refreshed view of the stack components
+    /// as they come online.
+    Watch,
     /// Install Dependencies
     Deps,
 }
@@ -38,8 +42,6 @@ pub fn run() -> Result<()> {
 
     crate::telemetry::init_tracing_subscriber(v)?;
 
-    crate::banners::banner()?;
-
     // Dispatch on the specified subcommand,
     // running the `up` subcommand by default.
     match command {
@@ -47,6 +49,7 @@ pub fn run() -> Result<()> {
         Some(command) => match command {
             Command::Up(up_command) => up_command.run(),
             Command::List => crate::list::run(),
+            Command::Watch => crate::watch::run(),
             Command::Down => unimplemented!("down command not yet implemented"),
             Command::Nuke => unimplemented!("nuke command not yet implemented"),
             Command::Clean => unimplemented!("clean command not yet implemented"),

--- a/bin/opup/src/lib.rs
+++ b/bin/opup/src/lib.rs
@@ -10,3 +10,4 @@ pub(crate) mod list;
 pub(crate) mod runner;
 pub(crate) mod telemetry;
 pub(crate) mod up;
+pub(crate) mod watch;

--- a/bin/opup/src/up.rs
+++ b/bin/opup/src/up.rs
@@ -61,6 +61,8 @@ impl UpCommand {
     /// Entrypoint
     #[instrument(name = "up", target = "run", skip(self))]
     pub fn run(&self) -> Result<()> {
+        crate::banners::banner()?;
+
         crate::runner::run_until_ctrl_c(async { self.execute().await })
     }
 }

--- a/bin/opup/src/watch.rs
+++ b/bin/opup/src/watch.rs
@@ -1,0 +1,37 @@
+use eyre::Result;
+use std::time::Duration;
+
+pub(crate) fn run() -> Result<()> {
+    crate::runner::run_until_ctrl_c(async {
+        loop {
+            // clear the terminal and reset the cursor to the top left
+            print!("\x1B[2J\x1B[1;1H");
+
+            let containers = op_composer::Composer::new()?
+                .list_containers(Some("running"))
+                .await?;
+
+            let mut table = prettytable::Table::new();
+            table.set_titles(prettytable::row!["Name", "Image", "Status", "Up Time"]);
+            for container in containers {
+                table.add_row(prettytable::row![
+                    container
+                        .names
+                        .map(|n| n.join(", "))
+                        .unwrap_or_else(|| "none".to_string()),
+                    container.image.unwrap_or_else(|| "none".to_string()),
+                    container.status.unwrap_or_else(|| "none".to_string()),
+                    container
+                        .created
+                        .map(|created| humantime::format_duration(Duration::from_secs(
+                            created as u64
+                        ))
+                        .to_string())
+                        .unwrap_or_else(|| "unknown".to_string())
+                ]);
+            }
+            table.printstd();
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    })
+}


### PR DESCRIPTION
Added a CLI `watch` command that outputs an auto-refreshing table that shows the running op-up containers.
This command duplicates most of the code of the `list` command made by @refcell, but I think it's fine as long as that is going to get refactored into `inspect` in #62 anyway.

I also moved the call to `crate::banners::banner()?;` in the up command itself, as I don't think it's necessary to show it on utility commands like `down`, `list`, etc